### PR TITLE
Fix malformed SASL messages

### DIFF
--- a/authentication_sasl_continue.go
+++ b/authentication_sasl_continue.go
@@ -40,7 +40,6 @@ func (src *AuthenticationSASLContinue) Encode(dst []byte) []byte {
 	dst = pgio.AppendInt32(dst, -1)
 	dst = pgio.AppendUint32(dst, AuthTypeSASLContinue)
 
-	dst = pgio.AppendInt32(dst, int32(len(src.Data)))
 	dst = append(dst, src.Data...)
 
 	pgio.SetInt32(dst[sp:], int32(len(dst[sp:])))

--- a/authentication_sasl_final.go
+++ b/authentication_sasl_final.go
@@ -40,7 +40,6 @@ func (src *AuthenticationSASLFinal) Encode(dst []byte) []byte {
 	dst = pgio.AppendInt32(dst, -1)
 	dst = pgio.AppendUint32(dst, AuthTypeSASLFinal)
 
-	dst = pgio.AppendInt32(dst, int32(len(src.Data)))
 	dst = append(dst, src.Data...)
 
 	pgio.SetInt32(dst[sp:], int32(len(dst[sp:])))


### PR DESCRIPTION
From user yulicrunchy:
Per the PG documentation [0], an AuthenticationSASLContinue message has:

    AuthenticationSASLContinue (B)
	Byte1('R')
	    Identifies the message as an authentication request.
	Int32
	    Length of message contents in bytes, including self.
	Int32(11)
	    Specifies that this message contains a SASL challenge.
	Byten
	    SASL data, specific to the SASL mechanism being used.

The current implementation was mistakenly adding the lengh of msg bytes
in between the Int32(11) and Byten. There was a similar issue for
AuthenticationSASLFinal.

[0] https://www.postgresql.org/docs/current/protocol-message-formats.html